### PR TITLE
Remove explicit `inline` directive

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,7 +136,6 @@ impl<K, V> Library<K, V> where K: LibraryKey {
         }
     }
 
-    #[inline]
     fn internal_data(&self) -> Arc<LibraryStore<K, V>> {
         self.internal_data.get()
     }


### PR DESCRIPTION
This was added (by me :disappointed:) on a mistaken whim and doesn't
reflect any actual insight.
